### PR TITLE
Increased resolution

### DIFF
--- a/OpenGL Template/OpenGL Template.vcxproj
+++ b/OpenGL Template/OpenGL Template.vcxproj
@@ -96,6 +96,9 @@
       <AdditionalLibraryDirectories>$(SolutionDir)Dependencies/glfw-32/lib-vc2019</AdditionalLibraryDirectories>
       <AdditionalDependencies>glfw3.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
+    <PostBuildEvent>
+      <Command>xcopy /y /i "$(ProjectDir)res/shaders" "$(OutDir)res/shaders"</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -111,6 +114,9 @@
       <AdditionalLibraryDirectories>$(SolutionDir)Dependencies/glfw-64/lib-vc2019</AdditionalLibraryDirectories>
       <AdditionalDependencies>glfw3.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
+    <PostBuildEvent>
+      <Command>xcopy /y /i "$(ProjectDir)res/shaders" "$(OutDir)res/shaders"</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -130,6 +136,9 @@
       <AdditionalLibraryDirectories>$(SolutionDir)Dependencies/glfw-32/lib-vc2019</AdditionalLibraryDirectories>
       <AdditionalDependencies>glfw3.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
+    <PostBuildEvent>
+      <Command>xcopy /y /i "$(ProjectDir)res/shaders" "$(OutDir)res/shaders"</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -149,6 +158,9 @@
       <AdditionalLibraryDirectories>$(SolutionDir)Dependencies/glfw-64/lib-vc2019</AdditionalLibraryDirectories>
       <AdditionalDependencies>glfw3.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
+    <PostBuildEvent>
+      <Command>xcopy /y /i "$(ProjectDir)res/shaders" "$(OutDir)res/shaders"</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="src\Config.cpp" />

--- a/OpenGL Template/imgui.ini
+++ b/OpenGL Template/imgui.ini
@@ -4,7 +4,7 @@ Size=400,400
 Collapsed=0
 
 [Window][Modify the fractal!]
-Pos=-13,17
-Size=458,301
+Pos=94,73
+Size=458,252
 Collapsed=0
 

--- a/OpenGL Template/res/shaders/fragment.shader
+++ b/OpenGL Template/res/shaders/fragment.shader
@@ -1,27 +1,34 @@
 #version 460 core
 
 layout (location = 0) out vec4 color;
-in float vertexX;
-in float vertexY;
-in vec2 vec;
+in vec2 vertex;
 
 uniform float r_Comp;
 uniform float z_Comp;
 uniform float rFac, gFac, bFac;
 uniform bool mandelbrot;
 
+// Visible Dimensions on screen
+uniform vec2 visible;
+uniform dvec2 corner;
+uniform float cellSize; // 160
+uniform float scale;
+
 void main() {
 
 	color = vec4(0, 0, 0, 1);
-	color = vec4(vec.x/10.0, vec.y/10.0, vec.x/10.0, 1);
-	const int max_itrs = 600;
+	//const int max_itrs = 600;
+	float max_itrs = 20 + sqrt(scale);
+	if (max_itrs > 700) max_itrs = 700;
+
+	dvec2 pos = dvec2(corner.x + vertex.x * visible.x, corner.y + vertex.y * visible.y);
 
 	if (!mandelbrot) {
-		float r = vertexX;
-		float z = vertexY;
+		double r = pos.x;
+		double z = pos.y;
 		for (int i = 0; i < max_itrs; i++) {
-			float rr = r * r - z * z + r_Comp;
-			float zz = 2 * r * z + z_Comp;
+			double rr = r * r - z * z + r_Comp;
+			double zz = 2 * r * z + z_Comp;
 			r = rr;
 			z = zz;
 
@@ -32,12 +39,12 @@ void main() {
 		}
 	}
 	else {
-		float r = 0;
-		float z = 0;
+		double r = 0;
+		double z = 0;
 		
 		for (int i = 0; i < max_itrs; i++) {
-			float rr = r * r - z * z + vertexX;
-			float zz = 2 * r * z + vertexY;
+			double rr = r * r - z * z + pos.x;
+			double zz = 2 * r * z + pos.y;
 			r = rr;
 			z = zz;
 

--- a/OpenGL Template/res/shaders/vertex.shader
+++ b/OpenGL Template/res/shaders/vertex.shader
@@ -1,22 +1,9 @@
 #version 460 core
 
 layout (location = 0) in vec2 pos;
-uniform mat4 u_ModelMat;
-uniform mat4 u_ViewMat;
-uniform mat4 u_ProjMat;
-
-// Width of x-axis and y-axis
-uniform vec2 axis;
-
-out float vertexX;
-out float vertexY;
-out vec2 vec;
-
+out vec2 vertex;
 
 void main() {
-	gl_Position = u_ProjMat * u_ViewMat * u_ModelMat * vec4(pos, 0.0f, 1.0);
-	vec = vec2(pos.x / (640.0 / axis.x), pos.y / (640.0 / axis.y));
-	vertexX = pos.x / (640.0 / axis.x);
-	vertexY = pos.y / (640.0 / axis.y);
-	
+	gl_Position = vec4(pos, 0.0f, 1.0);
+	vertex = vec2((1 + pos.x)/2, (1 + pos.y)/2);
 }

--- a/OpenGL Template/src/Config.cpp
+++ b/OpenGL Template/src/Config.cpp
@@ -14,8 +14,9 @@ Config::Config()
 	VIEW_BOTTOM(-320.f),
 	VIEW_TOP(320.f),
 	CELL_WIDTH(160),
-	AXIS_SIZE({5.f, 5.f}),
-	SENSITIVITY(0.5)
+	AXIS_SIZE({ 5.f, 5.f }),
+	SENSITIVITY(0.01),
+	CELL_SIZE(160)
 {}
 
 Config& c() {

--- a/OpenGL Template/src/Config.h
+++ b/OpenGL Template/src/Config.h
@@ -15,6 +15,7 @@ struct Config {
 	const float CELL_WIDTH;
 	const glm::vec2 AXIS_SIZE;
 	const double SENSITIVITY;
+	const float CELL_SIZE;
 
 	Config();
 };

--- a/OpenGL Template/src/engine/ShaderManager.cpp
+++ b/OpenGL Template/src/engine/ShaderManager.cpp
@@ -156,6 +156,10 @@ void ShaderProgram::setUniformBool(const char* name, bool val) {
 	glUniform1iv(getUniform(name), 1, &numVal);
 }
 
-void ShaderProgram::setUniformVec2(const char* name, glm::vec2& vector) {
+void ShaderProgram::setUniformVec2(const char* name, glm::vec2 vector) {
 	glUniform2fv(getUniform(name), 1, glm::value_ptr(vector));
+}
+
+void ShaderProgram::setUniformDVec2(const char* name, glm::dvec2 vector) {
+	glUniform2dv(getUniform(name), 1, glm::value_ptr(vector));
 }

--- a/OpenGL Template/src/engine/ShaderManager.h
+++ b/OpenGL Template/src/engine/ShaderManager.h
@@ -31,7 +31,8 @@ public:
 	void setUniform1d(const char* name, double val);
 	void setUniformMat4fv(const char* name, glm::mat4&);
 	void setUniformBool(const char* name, bool val);
-	void setUniformVec2(const char*, glm::vec2& val);
+	void setUniformVec2(const char*, glm::vec2 val);
+	void setUniformDVec2(const char* name, glm::dvec2 vector);
 	void Bind();
 	void Unbind();
 };


### PR DESCRIPTION
Increased the base resolution of the fractal renderer by using doubles instead of floats, because GLSL only does linear interpolation on floats a whole re-write of the coordinate system was required and I settled on using a mapping technique I came up with to convert screen coordinates to pixels on the complex plane. It works now.
I had to remove rotation for the time being since the old rotation system with matrices somehow bugged when I changed the scaling technique and because of the way the new system works, you would've had to view some portions with nothing in them if I had kept the old system.